### PR TITLE
Fixed #4 - use `.get` instead of `.is` which was removed in Lift 3.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ organization := "net.liftmodules"
 
 version := "1.2-SNAPSHOT"
 
-liftVersion <<= liftVersion ?? "2.5-SNAPSHOT"
+liftVersion <<= liftVersion ?? "2.5.1"
 
 liftEdition <<= liftVersion apply { _.substring(0,3) }
 


### PR DESCRIPTION
use `.get` instead of `.is` which was removed in Lift 3.0
Changed default lift version value to `2.5.1`

closes #4 
