### PR TITLE
Lift 3.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,53 +1,45 @@
+import LiftModule.{liftVersion, liftEdition}
+
 name := "machine"
 
 organization := "net.liftmodules"
 
-version := "1.3-SNAPSHOT"
+version := "1.3.0-SNAPSHOT"
 
-liftVersion <<= liftVersion ?? "2.6-SNAPSHOT"
+liftVersion := "3.0.1"
 
-liftEdition <<= liftVersion apply { _.substring(0,3) }
+liftEdition := (liftVersion apply { _.substring(0,3) }).value
 
-moduleName <<= (name, liftEdition) { (n, e) =>  n + "_" + e }
+moduleName := name.value + "_" + liftEdition.value
 
-scalaVersion := "2.11.0"
+scalaVersion := "2.12.1"
+
+crossScalaVersions := Seq("2.12.1", "2.11.8")
 
 scalacOptions ++= Seq("-unchecked", "-deprecation")
-
-crossScalaVersions := Seq("2.11.0", "2.10.0", "2.9.2", "2.9.1-1", "2.9.1")
 
 resolvers += "CB Central Mirror" at "http://repo.cloudbees.com/content/groups/public"
 
 resolvers += "Java.net Maven2 Repository" at "http://download.java.net/maven/2/"
 
-libraryDependencies <++= liftVersion { v =>
-  "net.liftweb" %% "lift-webkit" % v % "provided" ::
-  "net.liftweb" %% "lift-mapper" % v % "provided" ::
-  Nil
-}
+libraryDependencies += "net.liftweb" %% "lift-webkit" % liftVersion.value % "provided"
+libraryDependencies += "net.liftweb" %% "lift-mapper" % liftVersion.value % "provided"
 
 // For unit tests:
 
-libraryDependencies += "com.h2database" % "h2" % "1.3.170" % "test"
+libraryDependencies += "com.h2database" % "h2" % "1.4.193" % "test"
 
-libraryDependencies +=  "ch.qos.logback" % "logback-classic" % "1.0.6" % "test"
+libraryDependencies +=  "ch.qos.logback" % "logback-classic" % "1.1.8" % "test"
 
-libraryDependencies <++= scalaVersion { sv =>
-  (sv match {
-      case "2.9.2" | "2.9.1" | "2.9.1-1" => "org.specs2" %% "specs2" % "1.12.3" % "test"
-      case _ => "org.specs2" %% "specs2" % "2.3.11" % "test"
-      })  ::
-  Nil
-}
+libraryDependencies += "org.specs2" %% "specs2-core" % "3.8.6" % "test"
 
 parallelExecution in Test := false
 
 
-publishTo <<= version { _.endsWith("SNAPSHOT") match {
+publishTo := (version.value.endsWith("SNAPSHOT") match {
  	case true  => Some("snapshots" at "https://oss.sonatype.org/content/repositories/snapshots")
  	case false => Some("releases" at "https://oss.sonatype.org/service/local/staging/deploy/maven2")
-  }
- }
+})
 
 // For local deployment:
 
@@ -85,4 +77,3 @@ pomExtra := (
 	 	</developer>
 	 </developers>
  )
-

--- a/build.sbt
+++ b/build.sbt
@@ -41,13 +41,10 @@ publishTo := (version.value.endsWith("SNAPSHOT") match {
  	case false => Some("releases" at "https://oss.sonatype.org/service/local/staging/deploy/maven2")
 })
 
-// For local deployment:
-
-credentials += Credentials( file("sonatype.credentials") )
-
-// For the build server:
-
-credentials += Credentials( file("/private/liftmodules/sonatype.credentials") )
+credentials ++= (for {
+  username <- Option(System.getenv().get("SONATYPE_USERNAME"))
+  password <- Option(System.getenv().get("SONATYPE_PASSWORD"))
+} yield Credentials("Sonatype Nexus Repository Manager", "oss.sonatype.org", username, password)).toSeq
 
 publishMavenStyle := true
 

--- a/project/LiftModule.scala
+++ b/project/LiftModule.scala
@@ -1,12 +1,7 @@
 import sbt._
 import sbt.Keys._
 
-object LiftModuleBuild extends Build {
-
-  val liftVersion = SettingKey[String]("liftVersion", "Full version number of the Lift Web Framework")
-
-  val liftEdition = SettingKey[String]("liftEdition", "Lift Edition (short version number to append to artifact name)")
-
-  val project = Project("LiftModule", file("."))
-
+object LiftModule {
+  val liftVersion = settingKey[String]("Lift Web Framework full version number")
+  val liftEdition = settingKey[String]("Lift Edition (such as 2.6 or 3.0)")
 }

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.0
+sbt.version=0.13.13


### PR DESCRIPTION
Updated to use Lift 3.0.1 and migrated sbt format to 0.13.13. Scala versions before 2.11 have been dropped.